### PR TITLE
Symbol creation

### DIFF
--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/AttrScope.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/AttrScope.scala
@@ -6,15 +6,6 @@ object AttrScope {
   private def setCurrentAttr(attr: AttrScope): Unit = {
     _current = attr
   }
-
-  def withScope[T](attr: Map[String, String])(body: => T): T = {
-    val oldAttrScope = AttrScope.current
-    val updatedAttr = AttrScope.current.attr ++ attr
-    AttrScope.setCurrentAttr(new AttrScope(updatedAttr))
-    val ret = body
-    AttrScope.setCurrentAttr(oldAttrScope)
-    ret
-  }
 }
 
 /**
@@ -22,7 +13,8 @@ object AttrScope {
  * User can also inherit this object to change naming behavior.
  * @author Yizhi Liu
  */
-class AttrScope(private var attr: Map[String, String] = Map.empty) {
+class AttrScope(val attr: Map[String, String] = Map.empty) {
+  private var _attr = attr
   /**
    * Get the attribute dict given the attribute set by the symbol.
    * @param userDefinedAttr The attribute passed in by user during symbol creation.
@@ -30,5 +22,16 @@ class AttrScope(private var attr: Map[String, String] = Map.empty) {
    */
   def get(userDefinedAttr: Map[String, String]): Map[String, String] = {
     attr ++ userDefinedAttr
+  }
+
+  def withScope[T](body: => T): T = {
+    val oldAttrScope = AttrScope.current
+    this._attr = AttrScope.current.attr ++ this._attr
+    AttrScope.setCurrentAttr(this)
+    try {
+      body
+    } finally {
+      AttrScope.setCurrentAttr(oldAttrScope)
+    }
   }
 }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/AttrScope.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/AttrScope.scala
@@ -12,12 +12,8 @@ class AttrScope(attr: Map[String, String] = Map.empty) {
    * @param userDefinedAttr The attribute passed in by user during symbol creation.
    * @return Updated attributes to add other scope related attributes.
    */
-  def get(userDefinedAttr: Map[String, String]): Map[String, String] = {
-    if (userDefinedAttr != null) {
-      attr ++ userDefinedAttr
-    } else {
-      attr
-    }
+  def get(userDefinedAttr: Option[Map[String, String]]): Map[String, String] = {
+    _attr ++ userDefinedAttr.getOrElse(Map.empty[String, String])
   }
 
   def withScope[T](body: => T): T = {

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/AttrScope.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/AttrScope.scala
@@ -1,15 +1,5 @@
 package ml.dmlc.mxnet
 
-object AttrScope {
-  private var _current = new AttrScope()
-  def current: AttrScope = _current
-  private def setCurrentAttr(attr: AttrScope): Unit = {
-    _current = attr
-  }
-
-  def apply(attr: Map[String, String] = Map.empty): AttrScope = new AttrScope(attr)
-}
-
 /**
  * Attribute manager for scoping.
  * User can also inherit this object to change naming behavior.
@@ -40,4 +30,14 @@ class AttrScope(attr: Map[String, String] = Map.empty) {
       AttrScope.setCurrentAttr(oldAttrScope)
     }
   }
+}
+
+object AttrScope {
+  private var _current = new AttrScope()
+  def current: AttrScope = _current
+  private def setCurrentAttr(attr: AttrScope): Unit = {
+    _current = attr
+  }
+
+  def apply(attr: Map[String, String] = Map.empty): AttrScope = new AttrScope(attr)
 }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/AttrScope.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/AttrScope.scala
@@ -6,6 +6,8 @@ object AttrScope {
   private def setCurrentAttr(attr: AttrScope): Unit = {
     _current = attr
   }
+
+  def apply(attr: Map[String, String] = Map.empty): AttrScope = new AttrScope(attr)
 }
 
 /**
@@ -13,7 +15,7 @@ object AttrScope {
  * User can also inherit this object to change naming behavior.
  * @author Yizhi Liu
  */
-class AttrScope(val attr: Map[String, String] = Map.empty) {
+class AttrScope(attr: Map[String, String] = Map.empty) {
   private var _attr = attr
   /**
    * Get the attribute dict given the attribute set by the symbol.
@@ -21,12 +23,16 @@ class AttrScope(val attr: Map[String, String] = Map.empty) {
    * @return Updated attributes to add other scope related attributes.
    */
   def get(userDefinedAttr: Map[String, String]): Map[String, String] = {
-    attr ++ userDefinedAttr
+    if (userDefinedAttr != null) {
+      attr ++ userDefinedAttr
+    } else {
+      attr
+    }
   }
 
   def withScope[T](body: => T): T = {
     val oldAttrScope = AttrScope.current
-    this._attr = AttrScope.current.attr ++ this._attr
+    this._attr = AttrScope.current._attr ++ this._attr
     AttrScope.setCurrentAttr(this)
     try {
       body

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/AttrScope.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/AttrScope.scala
@@ -1,0 +1,34 @@
+package ml.dmlc.mxnet
+
+object AttrScope {
+  private var _current = new AttrScope()
+  def current: AttrScope = _current
+  private def setCurrentAttr(attr: AttrScope): Unit = {
+    _current = attr
+  }
+
+  def withScope[T](attr: Map[String, String])(body: => T): T = {
+    val oldAttrScope = AttrScope.current
+    val updatedAttr = AttrScope.current.attr ++ attr
+    AttrScope.setCurrentAttr(new AttrScope(updatedAttr))
+    val ret = body
+    AttrScope.setCurrentAttr(oldAttrScope)
+    ret
+  }
+}
+
+/**
+ * Attribute manager for scoping.
+ * User can also inherit this object to change naming behavior.
+ * @author Yizhi Liu
+ */
+class AttrScope(private var attr: Map[String, String] = Map.empty) {
+  /**
+   * Get the attribute dict given the attribute set by the symbol.
+   * @param userDefinedAttr The attribute passed in by user during symbol creation.
+   * @return Updated attributes to add other scope related attributes.
+   */
+  def get(userDefinedAttr: Map[String, String]): Map[String, String] = {
+    attr ++ userDefinedAttr
+  }
+}

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Base.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Base.scala
@@ -11,6 +11,8 @@ object Base {
   type MXFloat = Float
   type CPtrAddress = Long
 
+  type SymbolHandle = CPtrAddress
+
   type MXUintRef = RefInt
   type MXFloatRef = RefFloat
   type NDArrayHandle = RefLong
@@ -20,10 +22,8 @@ object Base {
   type KVStoreHandle = RefLong
   type ExecutorHandle = RefLong
 
-
   System.loadLibrary("mxnet-scala")
   val _LIB = new LibInfo
-
 
   // helper function definitions
   /**

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Base.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Base.scala
@@ -21,6 +21,7 @@ object Base {
   type DataIterCreator = RefLong
   type KVStoreHandle = RefLong
   type ExecutorHandle = RefLong
+  type SymbolHandleRef = RefLong
 
   System.loadLibrary("mxnet-scala")
   val _LIB = new LibInfo

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/IO.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/IO.scala
@@ -14,7 +14,7 @@ object IO {
   /**
    * create iterator via iterName and params
    * @param iterName name of iterator; "MNISTIter" or "ImageRecordIter"
-   * @param params paramters for create iterator
+   * @param params parameters for create iterator
    * @return
    */
   def createIterator(iterName: String, params: Map[String, String]): DataIter = {

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
@@ -131,4 +131,9 @@ class LibInfo {
                                           argTypes: ListBuffer[String],
                                           argDescs: ListBuffer[String],
                                           keyVarNumArgs: RefString): Int
+  @native def mxSymbolCreateAtomicSymbol(handle: SymbolHandle,
+                                         paramKeys: Array[String],
+                                         paramVals: Array[String],
+                                         symHandleRef: SymbolHandleRef): Int
+  @native def mxSymbolSetAttr(handle: SymbolHandle, key: String, value: String): Int
 }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
@@ -136,4 +136,13 @@ class LibInfo {
                                          paramVals: Array[String],
                                          symHandleRef: SymbolHandleRef): Int
   @native def mxSymbolSetAttr(handle: SymbolHandle, key: String, value: String): Int
+  @native def mxSymbolCompose(handle: SymbolHandle,
+                              name: String,
+                              keys: Array[String],
+                              args: Array[SymbolHandle]): Int
+  @native def mxSymbolCreateVariable(name: String, out: SymbolHandleRef): Int
+  @native def mxSymbolGetAttr(handle: SymbolHandle,
+                              key: String,
+                              ret: RefString,
+                              success: RefInt): Int
 }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
@@ -145,4 +145,11 @@ class LibInfo {
                               key: String,
                               ret: RefString,
                               success: RefInt): Int
+  @native def mxSymbolListArguments(handle: SymbolHandle,
+                                    arguments: ArrayBuffer[String]): Int
+  @native def mxSymbolCopy(handle: SymbolHandle, clonedHandle: SymbolHandleRef): Int
+  @native def mxSymbolListOutputs(handle: SymbolHandle,
+                                  outputs: ArrayBuffer[String]): Int
+  @native def mxSymbolCreateGroup(handles: Array[SymbolHandle], out: SymbolHandleRef): Int
+  @native def mxSymbolPrint(handle: SymbolHandle, str: RefString): Int
 }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
@@ -120,4 +120,15 @@ class LibInfo {
                                  grads: Array[CPtrAddress]): Int
   @native def mxExecutorPrint(handle: ExecutorHandle, debugStr: RefString): Int
   @native def mxExecutorSetMonitorCallback(handle: ExecutorHandle, callback: MXMonitorCallback): Int
+
+  // Symbols
+  @native def mxSymbolListAtomicSymbolCreators(symbolList: ListBuffer[SymbolHandle]): Int
+  @native def mxSymbolGetAtomicSymbolInfo(handle: SymbolHandle,
+                                          name: RefString,
+                                          desc: RefString,
+                                          numArgs: MXUintRef,
+                                          argNames: ListBuffer[String],
+                                          argTypes: ListBuffer[String],
+                                          argDescs: ListBuffer[String],
+                                          keyVarNumArgs: RefString): Int
 }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/NameManager.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/NameManager.scala
@@ -20,10 +20,8 @@ class NameManager {
    * @param hint : A hint string, which can be used to generate name.
    * @return A canonical name for the user.
    */
-  def get(name: String, hint: String): String = {
-    if (name != null) {
-      name
-    } else {
+  def get(name: Option[String], hint: String): String = {
+    name.getOrElse {
       if (!counter.contains(hint)) {
         counter(hint) = 0
       }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/NameManager.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/NameManager.scala
@@ -1,0 +1,56 @@
+package ml.dmlc.mxnet
+
+import scala.collection.mutable
+
+/**
+ * NameManager to do automatic naming.
+ * User can also inherit this object to change naming behavior.
+ * @author Yizhi Liu
+ */
+class NameManager {
+  val counter: mutable.Map[String, Int] = mutable.HashMap.empty[String, Int]
+  /**
+   * Get the canonical name for a symbol.
+   *     This is default implementation.
+   *     When user specified a name,
+   *     the user specified name will be used.
+   *
+   *     When user did not, we will automatically generate a
+   *     name based on hint string.
+   * @param name : str or None
+            The name user specified.
+   * @param hint : str
+            A hint string, which can be used to generate name.
+   * @return A canonical name for the user.
+   */
+  def get(name: String, hint: String): String = {
+    if (name != null) {
+      name
+    } else {
+      if (!counter.contains(hint)) {
+        counter(hint) = 0
+      }
+      val name = s"$hint${counter(hint)}"
+      counter(hint) += 1
+      name
+    }
+  }
+
+  def withScope[T](body: => T): T = {
+    val oldManager = NameManager.current
+    NameManager.setCurrentManager(this)
+    try {
+      body
+    } finally {
+      NameManager.setCurrentManager(oldManager)
+    }
+  }
+}
+
+object NameManager {
+  private var _current = new NameManager()
+  def current: NameManager = _current
+  private def setCurrentManager(manager: NameManager): Unit = {
+    _current = manager
+  }
+}

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/NameManager.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/NameManager.scala
@@ -11,16 +11,13 @@ class NameManager {
   val counter: mutable.Map[String, Int] = mutable.HashMap.empty[String, Int]
   /**
    * Get the canonical name for a symbol.
-   *     This is default implementation.
-   *     When user specified a name,
-   *     the user specified name will be used.
+   * This is default implementation.
+   * When user specified a name,
+   * the user specified name will be used.
+   * When user did not, we will automatically generate a name based on hint string.
    *
-   *     When user did not, we will automatically generate a
-   *     name based on hint string.
-   * @param name : str or None
-            The name user specified.
-   * @param hint : str
-            A hint string, which can be used to generate name.
+   * @param name : The name user specified.
+   * @param hint : A hint string, which can be used to generate name.
    * @return A canonical name for the user.
    */
   def get(name: String, hint: String): String = {
@@ -30,9 +27,9 @@ class NameManager {
       if (!counter.contains(hint)) {
         counter(hint) = 0
       }
-      val name = s"$hint${counter(hint)}"
+      val generatedName = s"$hint${counter(hint)}"
       counter(hint) += 1
-      name
+      generatedName
     }
   }
 

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
@@ -1,6 +1,46 @@
 package ml.dmlc.mxnet
 
-class Symbol {
+import ml.dmlc.mxnet.Base._
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable.ListBuffer
+
+object Symbol {
+  private val logger = LoggerFactory.getLogger(classOf[Symbol])
+  private val functions: Map[String, SymbolFunction] = initSymbolModule()
+
+  // List and add all the atomic symbol functions to current module.
+  private def initSymbolModule(): Map[String, SymbolFunction] = {
+    val symbolList = ListBuffer.empty[SymbolHandle]
+    checkCall(_LIB.mxSymbolListAtomicSymbolCreators(symbolList))
+    symbolList.map(makeAtomicSymbolFunction).toMap
+  }
+
+  // Create an atomic symbol function by handle and funciton name.
+  private def makeAtomicSymbolFunction(handle: SymbolHandle): (String, SymbolFunction) = {
+    val name = new RefString
+    val desc = new RefString
+    val keyVarNumArgs = new RefString
+    val numArgs = new MXUintRef
+    val argNames = ListBuffer.empty[String]
+    val argTypes = ListBuffer.empty[String]
+    val argDescs = ListBuffer.empty[String]
+
+    checkCall(_LIB.mxSymbolGetAtomicSymbolInfo(
+      handle, name, desc, numArgs, argNames, argTypes, argDescs, keyVarNumArgs))
+    val paramStr = ctypes2docstring(argNames, argTypes, argDescs)
+    val docStr = s"${name.value}\n${desc.value}\n\n$paramStr\n"
+    logger.debug("Atomic Symbol function defination:\n{}", docStr)
+    (name.value, new SymbolFunction(handle, keyVarNumArgs.value))
+  }
+}
+
+class Symbol(private[mxnet] val handle: SymbolHandle) {
+  def +(other: Symbol): Symbol = ???
+  def +(other: Int): Symbol = ???
+  def +(other: Float): Symbol = ???
+  def +(other: Double): Symbol = ???
+
   /**
    * List all the arguments in the symbol.
    * @return Array of all the arguments.
@@ -19,3 +59,5 @@ class Symbol {
    */
   def listAuxiliaryStates(): Array[String] = ???
 }
+
+case class SymbolFunction(handle: SymbolHandle, keyVarNumArgs: String)

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
@@ -5,94 +5,12 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.mutable.ListBuffer
 
-object Symbol {
-  private val logger = LoggerFactory.getLogger(classOf[Symbol])
-  private val functions: Map[String, SymbolFunction] = initSymbolModule()
-
-  /**
-   * Create a symbolic variable with specified name.
-   * @param name Name of the variable.
-   * @param attr dict of string -> string
-       Additional attributes to set on the variable.
-   * @return The created variable symbol.
-   */
-  def Variable(name: String, attr: Map[String, String] = null): Symbol = {
-    val handle = new SymbolHandleRef
-    checkCall(_LIB.mxSymbolCreateVariable(name, handle))
-    val sym = new Symbol(handle.value)
-    sym.setAttr(AttrScope.current.get(attr))
-    sym
-  }
-
-  // List and add all the atomic symbol functions to current module.
-  private def initSymbolModule(): Map[String, SymbolFunction] = {
-    val symbolList = ListBuffer.empty[SymbolHandle]
-    checkCall(_LIB.mxSymbolListAtomicSymbolCreators(symbolList))
-    symbolList.map(makeAtomicSymbolFunction).toMap
-  }
-
-  // Create an atomic symbol function by handle and function name.
-  private def makeAtomicSymbolFunction(handle: SymbolHandle): (String, SymbolFunction) = {
-    val name = new RefString
-    val desc = new RefString
-    val keyVarNumArgs = new RefString
-    val numArgs = new MXUintRef
-    val argNames = ListBuffer.empty[String]
-    val argTypes = ListBuffer.empty[String]
-    val argDescs = ListBuffer.empty[String]
-
-    checkCall(_LIB.mxSymbolGetAtomicSymbolInfo(
-      handle, name, desc, numArgs, argNames, argTypes, argDescs, keyVarNumArgs))
-    val paramStr = ctypes2docstring(argNames, argTypes, argDescs)
-    val docStr = s"${name.value}\n${desc.value}\n\n$paramStr\n"
-    logger.debug("Atomic Symbol function defination:\n{}", docStr)
-    (name.value, new SymbolFunction(handle, keyVarNumArgs.value))
-  }
-
-  /**
-   * Activation Operator of Neural Net.
-   * The parameters listed below can be passed in as keyword arguments.
-   * @param name Name of the resulting symbol.
-   *             // TODO
-   * @return the resulting symbol
-   */
-  def creator(operator: String,
-              name: String,
-              attr: Map[String, String],
-              paramKwargs: Map[String, String],
-              symbols: Symbol*): Symbol = {
-    val function = functions(operator)
-    require(function != null, s"invalid operator name $operator")
-
-    val addkeyVarNumArgs =
-      (function.keyVarNumArgs != null) && !paramKwargs.contains(function.keyVarNumArgs)
-
-    val paramKeys: Array[String] = (
-        if (addkeyVarNumArgs) Array[String](function.keyVarNumArgs)
-        else Array.empty[String]
-      ) ++ paramKwargs.keys
-    val paramVals: Array[String] = (
-        if (addkeyVarNumArgs) Array[String](symbols.length.toString)
-        else Array.empty[String]
-      ) ++ paramKwargs.values
-
-    // create atomic symbol
-    val symHandle = new SymbolHandleRef
-    checkCall(_LIB.mxSymbolCreateAtomicSymbol(
-      function.handle, paramKeys, paramVals, symHandle))
-
-    val s = new Symbol(symHandle.value)
-    val attrAll = AttrScope.current.get(attr)
-    s.setAttr(attrAll)
-    val hint = operator.toLowerCase
-    val managedName = NameManager.current.get(name, hint)
-    s.compose(name = managedName, symbols.toArray)
-    s
-  }
-}
-
+/**
+ * Symbolic configuration API of mxnet.
+ * @author Yizhi Liu
+ */
 class Symbol(private[mxnet] val handle: SymbolHandle) {
-  def +(other: Symbol): Symbol = ???
+  def +(other: Symbol): Symbol = Symbol.creator("_Plus", other)
   def +(other: Int): Symbol = ???
   def +(other: Float): Symbol = ???
   def +(other: Double): Symbol = ???
@@ -149,6 +67,132 @@ class Symbol(private[mxnet] val handle: SymbolHandle) {
     checkCall(_LIB.mxSymbolCompose(handle, name, null, args))
   }
 
+  private def compose(name: String, symbols: Map[String, Symbol]): Unit = {
+    val keys = symbols.keys.toArray
+    val args = symbols.values.map(_.handle).toArray
+    checkCall(_LIB.mxSymbolCompose(handle, name, null, args))
+  }
 }
 
-case class SymbolFunction(handle: SymbolHandle, keyVarNumArgs: String)
+object Symbol {
+  private val logger = LoggerFactory.getLogger(classOf[Symbol])
+  private val functions: Map[String, SymbolFunction] = initSymbolModule()
+
+  /**
+   * Create a symbolic variable with specified name.
+   * @param name Name of the variable.
+   * @param attr Additional attributes to set on the variable.
+   * @return The created variable symbol.
+   */
+  def Variable(name: String, attr: Map[String, String] = null): Symbol = {
+    val handle = new SymbolHandleRef
+    checkCall(_LIB.mxSymbolCreateVariable(name, handle))
+    val sym = new Symbol(handle.value)
+    sym.setAttr(AttrScope.current.get(attr))
+    sym
+  }
+
+  // List and add all the atomic symbol functions to current module.
+  private def initSymbolModule(): Map[String, SymbolFunction] = {
+    val symbolList = ListBuffer.empty[SymbolHandle]
+    checkCall(_LIB.mxSymbolListAtomicSymbolCreators(symbolList))
+    symbolList.map(makeAtomicSymbolFunction).toMap
+  }
+
+  // Create an atomic symbol function by handle and function name.
+  private def makeAtomicSymbolFunction(handle: SymbolHandle): (String, SymbolFunction) = {
+    val name = new RefString
+    val desc = new RefString
+    val keyVarNumArgs = new RefString
+    val numArgs = new MXUintRef
+    val argNames = ListBuffer.empty[String]
+    val argTypes = ListBuffer.empty[String]
+    val argDescs = ListBuffer.empty[String]
+
+    checkCall(_LIB.mxSymbolGetAtomicSymbolInfo(
+      handle, name, desc, numArgs, argNames, argTypes, argDescs, keyVarNumArgs))
+    val paramStr = ctypes2docstring(argNames, argTypes, argDescs)
+    val docStr = s"${name.value}\n${desc.value}\n\n$paramStr\n"
+    logger.debug("Atomic Symbol function defination:\n{}", docStr)
+    (name.value, new SymbolFunction(handle, keyVarNumArgs.value))
+  }
+
+  /**
+   * Activation Operator of Neural Net.
+   * The parameters listed below can be passed in as keyword arguments.
+   * @param name Name of the resulting symbol.
+   *             // TODO
+   * @return the resulting symbol
+   */
+  private def creator(operator: String,
+                      name: String,
+                      attr: Map[String, String],
+                      paramKwargs: Map[String, String],
+                      symbols: Symbol*): Symbol = {
+    val function = functions(operator)
+    require(function != null, s"invalid operator name $operator")
+
+    val addkeyVarNumArgs = (function.keyVarNumArgs != null
+      && !function.keyVarNumArgs.isEmpty
+      && !paramKwargs.contains(function.keyVarNumArgs))
+
+    val paramKeys: Array[String] = (
+        if (addkeyVarNumArgs) Array[String](function.keyVarNumArgs)
+        else Array.empty[String]
+      ) ++ paramKwargs.keys
+    val paramVals: Array[String] = (
+        if (addkeyVarNumArgs) Array[String](symbols.length.toString)
+        else Array.empty[String]
+      ) ++ paramKwargs.values
+
+    // create atomic symbol
+    val symHandle = new SymbolHandleRef
+    checkCall(_LIB.mxSymbolCreateAtomicSymbol(
+      function.handle, paramKeys, paramVals, symHandle))
+
+    val s = new Symbol(symHandle.value)
+    val attrAll = AttrScope.current.get(attr)
+    s.setAttr(attrAll)
+    val hint = operator.toLowerCase
+    val managedName = NameManager.current.get(name, hint)
+    s.compose(managedName, symbols.toArray)
+    s
+  }
+
+  private def creator(operator: String, symbols: Symbol*): Symbol = {
+    creator(operator, null, null, Map.empty[String, String], symbols:_*)
+  }
+
+  private def creator(operator: String,
+                      name: String,
+                      attr: Map[String, String],
+                      paramKwargs: Map[String, String],
+                      symbols: Map[String, Symbol]): Symbol = {
+    val function = functions(operator)
+    require(function != null, s"invalid operator name $operator")
+    require(function.keyVarNumArgs == null || function.keyVarNumArgs.isEmpty,
+      "This function support variable length of Symbol arguments.\n" +
+      "Please pass all the input Symbols via positional arguments instead of keyword arguments.")
+
+    val paramKeys = paramKwargs.keys.toArray
+    val paramVals = paramKwargs.values.toArray
+    val symHandle = new SymbolHandleRef
+    checkCall(_LIB.mxSymbolCreateAtomicSymbol(
+      function.handle, paramKeys, paramVals, symHandle))
+
+    val s = new Symbol(symHandle.value)
+    val attrAll = AttrScope.current.get(attr)
+    s.setAttr(attrAll)
+    val hint = operator.toLowerCase
+    val managedName = NameManager.current.get(name, hint)
+    s.compose(managedName, symbols)
+    s
+  }
+
+  private def creator(operator: String, symbols: Map[String, Symbol]): Symbol = {
+    creator(operator, null, null, Map.empty[String, String], symbols)
+  }
+
+}
+
+private case class SymbolFunction(handle: SymbolHandle, keyVarNumArgs: String)

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
@@ -70,8 +70,8 @@ object Symbol {
     val attrAll = AttrScope.current.get(attr)
     s.setAttr(attrAll)
     val hint = operator.toLowerCase
+    val managedName = NameManager.current.get(name, hint)
     /* TODO
-    name = NameManager.current.get(name, hint)
     s._compose(*args, name = name, **symbol_kwargs)
     */
     s

--- a/scala-package/core/src/test/scala/ml/dmlc/mxnet/AttrScopeSuite.scala
+++ b/scala-package/core/src/test/scala/ml/dmlc/mxnet/AttrScopeSuite.scala
@@ -1,0 +1,19 @@
+package ml.dmlc.mxnet
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+class AttrScopeSuite extends FunSuite with BeforeAndAfterAll {
+  test("attr basic") {
+    val (data, gdata) =
+    AttrScope(Map("group" -> "4", "data" -> "great")).withScope {
+      val data = Symbol.Variable("data", attr = Map("dtype" -> "data", "group" -> "1"))
+      val gdata = Symbol.Variable("data2")
+      (data, gdata)
+    }
+    assert(gdata.attr("group").get === "4")
+    assert(data.attr("group").get === "1")
+
+    val exceedScopeData = Symbol.Variable("data3")
+    assert(exceedScopeData.attr("group") === None, "No group attr in global attr scope")
+  }
+}

--- a/scala-package/core/src/test/scala/ml/dmlc/mxnet/SymbolSuite.scala
+++ b/scala-package/core/src/test/scala/ml/dmlc/mxnet/SymbolSuite.scala
@@ -1,0 +1,12 @@
+package ml.dmlc.mxnet
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+class SymbolSuite extends FunSuite with BeforeAndAfterAll {
+  test("plus") {
+    val sym1 = Symbol.Variable("data1")
+    val sym2 = Symbol.Variable("data2")
+    val symPlus = sym1 + sym2
+    // TODO: check result
+  }
+}

--- a/scala-package/core/src/test/scala/ml/dmlc/mxnet/SymbolSuite.scala
+++ b/scala-package/core/src/test/scala/ml/dmlc/mxnet/SymbolSuite.scala
@@ -3,10 +3,26 @@ package ml.dmlc.mxnet
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 class SymbolSuite extends FunSuite with BeforeAndAfterAll {
-  test("plus") {
-    val sym1 = Symbol.Variable("data1")
-    val sym2 = Symbol.Variable("data2")
-    val symPlus = sym1 + sym2
-    // TODO: check result
+  test("symbol compose") {
+    val data = Symbol.Variable("data")
+
+    var net1 = Symbol.FullyConnected(Map("data" -> data, "name" -> "fc1", "num_hidden" -> 10))
+    net1 = Symbol.FullyConnected(Map("data" -> net1, "name" -> "fc2", "num_hidden" -> 100))
+    assert(net1.listArguments() ===
+      Array("data", "fc1_weight", "fc1_bias", "fc2_weight", "fc2_bias"))
+
+    var net2 = Symbol.FullyConnected(Map("name" -> "fc3", "num_hidden" -> 10))
+    net2 = Symbol.Activation(Map("data" -> net2, "act_type" -> "relu"))
+    net2 = Symbol.FullyConnected(Map("data" -> net2, "name" -> "fc4", "num_hidden" -> 20))
+    // scalastyle:off println
+    println(s"net2 debug info:\n${net2.debugStr}")
+    // scalastyle:on println
+
+    val composed = net2(name = "composed", Map("fc3_data" -> net1))
+    // scalastyle:off println
+    println(s"composed debug info:\n${composed.debugStr}")
+    // scalastyle:on println
+    val multiOut = Symbol.Group(composed, net1)
+    assert(multiOut.listOutputs().length === 2)
   }
 }

--- a/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
@@ -780,15 +780,25 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxSymbolCompose
   int argSize = env->GetArrayLength(jargs);
   const char **keys = NULL;
   if (jkeys != NULL) {
-    // TODO
+    keys = new const char*[argSize];
+    for (int i = 0; i < argSize; i++) {
+      jstring jkey = (jstring) env->GetObjectArrayElement(jkeys, i);
+      const char *key = env->GetStringUTFChars(jkey, 0);
+      keys[i] = key;
+    }
   }
   jlong *args = env->GetLongArrayElements(jargs, NULL);
   const char *name = env->GetStringUTFChars(jname, 0);
   int ret = MXSymbolCompose((SymbolHandle) symbolPtr,
                             name, (mx_uint) argSize, keys,
                             (SymbolHandle*) args);
+  // release allocated memory
   if (jkeys != NULL) {
-    // TODO
+    for (int i = 0; i < argSize; i++) {
+      jstring jkey = (jstring) env->GetObjectArrayElement(jkeys, i);
+      env->ReleaseStringUTFChars(jkey, keys[i]);
+    }
+    delete[] keys;
   }
   env->ReleaseStringUTFChars(jname, name);
   env->ReleaseLongArrayElements(jargs, args, 0);

--- a/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
@@ -773,3 +773,48 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxSymbolSetAttr
   env->ReleaseStringUTFChars(jvalue, cvalue);
   return ret;
 }
+
+JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxSymbolCompose
+  (JNIEnv *env, jobject obj, jlong symbolPtr, jstring jname,
+   jobjectArray jkeys, jlongArray jargs) {
+  int argSize = env->GetArrayLength(jargs);
+  const char **keys = NULL;
+  if (jkeys != NULL) {
+    // TODO
+  }
+  jlong *args = env->GetLongArrayElements(jargs, NULL);
+  const char *name = env->GetStringUTFChars(jname, 0);
+  int ret = MXSymbolCompose((SymbolHandle) symbolPtr,
+                            name, (mx_uint) argSize, keys,
+                            (SymbolHandle*) args);
+  if (jkeys != NULL) {
+    // TODO
+  }
+  env->ReleaseStringUTFChars(jname, name);
+  env->ReleaseLongArrayElements(jargs, args, 0);
+  return ret;
+}
+
+JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxSymbolCreateVariable
+  (JNIEnv *env, jobject obj, jstring jname, jobject handle) {
+  SymbolHandle out;
+  const char *name = env->GetStringUTFChars(jname, 0);
+  int ret = MXSymbolCreateVariable(name, &out);
+  env->ReleaseStringUTFChars(jname, name);
+  setLongField(env, handle, (long)out);
+  return ret;
+}
+
+JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxSymbolGetAttr
+  (JNIEnv *env, jobject obj, jlong symbolPtr, jstring jkey, jobject retRef, jobject successRef) {
+
+  const char *out;
+  int success;
+  const char *key = env->GetStringUTFChars(jkey, 0);
+  int ret = MXSymbolGetAttr((SymbolHandle) symbolPtr, key, &out, &success);
+  env->ReleaseStringUTFChars(jkey, key);
+
+  setStringField(env, retRef, out);
+  setIntField(env, successRef, success);
+  return ret;
+}

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -203,6 +203,11 @@
         <version>${scala.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-reflect</artifactId>
+        <version>${scala.version}</version>
+      </dependency>
+      <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>1.10</version>


### PR DESCRIPTION
* Create Symbol using Symbol::create. I provided multiple apis, including closures, to make creation as easy as possible.
* AttrScope and NameManager, you can use withScope to do exactly the same thing in python.
* Finished java_ml_dmlc_mxnet_LibInfo_mxNDArrayFree

FYI @yanqingmen I found that define SymbolHandle pure long, and define another SymbolHandleRef = RefLong is a better way to deal with handles, (see changes in Base.scala), since most time we take the ptr address directly. I'll modify NDArray as well. Please modify DataIters the same way here if you have time.