### PR TITLE
Fix training bug, sgd bug, initializer bug

### DIFF
--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Optimizer.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Optimizer.scala
@@ -14,10 +14,26 @@ object Optimizer {
   }
 }
 
-abstract class Optimizer(protected var rescaleGrad: Float = 1f) extends Serializable {
+abstract class Optimizer(protected var rescaleGrad: Float = 1f,
+                         protected val argNames: Seq[String] = null) extends Serializable {
   protected var lrScale: mutable.Map[Int, Float] = mutable.HashMap.empty[Int, Float]
   protected var numUpdate: Int = 0
   protected val indexUpdateCount: mutable.Map[Int, Int] = mutable.HashMap.empty[Int, Int]
+
+  protected var specialized: Boolean = false
+  protected val weightSet: mutable.Set[Int] = mutable.HashSet.empty[Int]
+  if (argNames != null) {
+    specialized = true
+    var index = 0
+    argNames foreach { name =>
+      if (!name.endsWith("data") && !name.endsWith("label")) {
+        if (name.endsWith("weight")) {
+          weightSet.add(index)
+        }
+        index += 1
+      }
+    }
+  }
 
   /**
    * Update the parameters.

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Random.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Random.scala
@@ -25,7 +25,7 @@ object Random {
               out: NDArray = null): NDArray = {
     var outCopy = out
     if (outCopy != null) {
-      require(shape == null & ctx == null, "shape and ctx is not needed when out is specified.")
+      require(shape == null && ctx == null, "shape and ctx is not needed when out is specified.")
     } else {
       require(shape != null, "shape is required when out is not specified")
       outCopy = empty(shape, ctx)


### PR DESCRIPTION
As title.
Now we have Train-accuracy=0.94346666 with Scala, V.S. Train-accuracy=0.942483 with Python.
The slight difference between these two accuracies is due to the different order of (uniformly) initializing arg_params in Model::init_params. I dumped some debug infos:

python:
```
init arg_params: Use initializer for bn1_beta
init arg_params: Use initializer for fc2_bias
init arg_params: Use initializer for fc2_weight
init arg_params: Use initializer for conv1_bias
init arg_params: Use initializer for bn2_gamma
init arg_params: Use initializer for conv2_bias
init arg_params: Use initializer for conv2_weight
init arg_params: Use initializer for bn1_gamma
init arg_params: Use initializer for bn2_beta
init arg_params: Use initializer for conv1_weight
init aux_params: Use initializer for bn1_moving_mean
init aux_params: Use initializer for bn1_moving_var
init aux_params: Use initializer for bn2_moving_mean
init aux_params: Use initializer for bn2_moving_var
```

scala:
```
init arg_params: Use initializer for bn1_gamma
init arg_params: Use initializer for conv2_bias
init arg_params: Use initializer for bn1_beta
init arg_params: Use initializer for fc2_weight
init arg_params: Use initializer for bn2_gamma
init arg_params: Use initializer for bn2_beta
init arg_params: Use initializer for conv1_bias
init arg_params: Use initializer for conv1_weight
init arg_params: Use initializer for fc2_bias
init arg_params: Use initializer for conv2_weight
init aux_params: Use initializer for bn1_moving_mean
init aux_params: Use initializer for bn1_moving_var
init aux_params: Use initializer for bn2_moving_mean
init aux_params: Use initializer for bn2_moving_var
```
